### PR TITLE
7tv CDN URL fix

### DIFF
--- a/src/util/requests/emotes.js
+++ b/src/util/requests/emotes.js
@@ -27,7 +27,7 @@ const urls = {
     channel: (channelName) =>
       `https://api.7tv.app/v2/users/${channelName}/emotes`,
     global: () => 'https://api.7tv.app/v2/emotes/global',
-    cdn: (emoteId) => `https://cdn.7tv.app/emote/${emoteId}/3x`,
+    cdn: (emoteId) => `https://cdn.7tv.app/emote/${emoteId}/3x.webp`,
   },
 };
 


### PR DESCRIPTION
As reported by badoge in issue https://github.com/Mahcks/YEAHBUTDVDs/issues/16, there's an issue with the 7tv CDN URLs since they been changed. Pushing this change for now since it seems to have fixed most channels I've tested. 